### PR TITLE
Remove ability to chain setters where not needed

### DIFF
--- a/src/Petrinet/Arc/Arc.php
+++ b/src/Petrinet/Arc/Arc.php
@@ -81,8 +81,6 @@ class Arc implements ArcInterface
      *
      * @param integer $direction The direction
      *
-     * @return Arc This method is chainable
-     *
      * @throws \InvalidArgumentException
      */
     public function setDirection($direction)
@@ -97,8 +95,6 @@ class Arc implements ArcInterface
         }
 
         $this->direction = $direction;
-
-        return $this;
     }
 
     /**
@@ -115,14 +111,10 @@ class Arc implements ArcInterface
      * Sets the transition.
      *
      * @param TransitionInterface $transition The transition
-     *
-     * @return Arc This method is chainable
      */
     public function setTransition(TransitionInterface $transition)
     {
         $this->transition = $transition;
-
-        return $this;
     }
 
     /**
@@ -139,14 +131,10 @@ class Arc implements ArcInterface
      * Sets the place.
      *
      * @param PlaceInterface $place The place
-     *
-     * @return Arc This method is chainable
      */
     public function setPlace(PlaceInterface $place)
     {
         $this->place = $place;
-
-        return $this;
     }
 
     /**

--- a/src/Petrinet/Engine/Engine.php
+++ b/src/Petrinet/Engine/Engine.php
@@ -107,8 +107,6 @@ class Engine implements EngineInterface
     public function setPetrinet(PetrinetInterface $petrinet)
     {
         $this->petrinet = $petrinet;
-
-        return $this;
     }
 
     /**
@@ -125,8 +123,6 @@ class Engine implements EngineInterface
     public function setState(EngineStateInterface $state)
     {
         $this->state = $state;
-
-        return $this;
     }
 
     /**
@@ -178,8 +174,6 @@ class Engine implements EngineInterface
      * @param integer $mode The execution mode
      *
      * @throws \InvalidArgumentException
-     *
-     * @return Engine
      */
     public function setMode($mode)
     {
@@ -193,8 +187,6 @@ class Engine implements EngineInterface
         }
 
         $this->mode = $mode;
-
-        return $this;
     }
 
     /**

--- a/src/Petrinet/Node/AbstractNode.php
+++ b/src/Petrinet/Node/AbstractNode.php
@@ -67,30 +67,22 @@ abstract class AbstractNode implements NodeInterface
      * Adds an input arc.
      *
      * @param ArcInterface $arc The arc
-     *
-     * @return AbstractNode This method is chainable
      */
     public function addInputArc(ArcInterface $arc)
     {
         $this->inputArcs[] = $arc;
-
-        return $this;
     }
 
     /**
      * Adds multiple input arcs at once.
      *
      * @param ArcInterface[] $inputArcs The arcs
-     *
-     * @return AbstractNode This method is chainable
      */
     public function addInputArcs(array $inputArcs)
     {
         foreach ($inputArcs as $inputArc) {
             $this->addInputArc($inputArc);
         }
-
-        return $this;
     }
 
     /**
@@ -115,30 +107,22 @@ abstract class AbstractNode implements NodeInterface
      * Adds an output arc.
      *
      * @param ArcInterface $arc The arc
-     *
-     * @return AbstractNode This method is chainable
      */
     public function addOutputArc(ArcInterface $arc)
     {
         $this->outputArcs[] = $arc;
-
-        return $this;
     }
 
     /**
      * Adds multiple output arcs at once.
      *
      * @param ArcInterface[] $outputArcs The arcs
-     *
-     * @return AbstractNode This method is chainable
      */
     public function addOutputArcs(array $outputArcs)
     {
         foreach ($outputArcs as $outputArc) {
             $this->addOutputArc($outputArc);
         }
-
-        return $this;
     }
 
     /**

--- a/src/Petrinet/Petrinet.php
+++ b/src/Petrinet/Petrinet.php
@@ -78,30 +78,22 @@ class Petrinet implements PetrinetInterface
      * Adds a place.
      *
      * @param PlaceInterface $place The place
-     *
-     * @return Petrinet This method is chainable
      */
     public function addPlace(PlaceInterface $place)
     {
         $this->places[$place->getId()] = $place;
-
-        return $this;
     }
 
     /**
      * Adds multiple places at once.
      *
      * @param PlaceInterface[] $places The places
-     *
-     * @return Petrinet This method is chainable
      */
     public function addPlaces(array $places)
     {
         foreach ($places as $place) {
             $this->addPlace($place);
         }
-
-        return $this;
     }
 
     /**
@@ -128,30 +120,22 @@ class Petrinet implements PetrinetInterface
      * Adds a transition.
      *
      * @param TransitionInterface $transition The transition
-     *
-     * @return Petrinet This method is chainable
      */
     public function addTransition(TransitionInterface $transition)
     {
         $this->transitions[$transition->getId()] = $transition;
-
-        return $this;
     }
 
     /**
      * Adds multiple transitions at once.
      *
      * @param TransitionInterface[] $transitions The transitions
-     *
-     * @return Petrinet This method is chainable
      */
     public function addTransitions(array $transitions)
     {
         foreach ($transitions as $transition) {
             $this->addTransition($transition);
         }
-
-        return $this;
     }
 
     /**
@@ -178,30 +162,22 @@ class Petrinet implements PetrinetInterface
      * Adds an arc.
      *
      * @param ArcInterface $arc The arc
-     *
-     * @return Petrinet This method is chainable
      */
     public function addArc(ArcInterface $arc)
     {
         $this->arcs[$arc->getId()] = $arc;
-
-        return $this;
     }
 
     /**
      * Adds multiple arcs at once.
      *
      * @param ArcInterface[] $arcs The arcs
-     *
-     * @return Petrinet This method is chainable
      */
     public function addArcs(array $arcs)
     {
         foreach ($arcs as $arc) {
             $this->addArc($arc);
         }
-
-        return $this;
     }
 
     /**

--- a/src/Petrinet/PetrinetBuilder.php
+++ b/src/Petrinet/PetrinetBuilder.php
@@ -298,10 +298,9 @@ final class PetrinetBuilder
     public function getPetrinet()
     {
         $petrinet = new Petrinet($this->id);
-        $petrinet
-            ->addPlaces($this->places)
-            ->addTransitions($this->transitions)
-            ->addArcs($this->arcs);
+        $petrinet->addPlaces($this->places);
+        $petrinet->addTransitions($this->transitions);
+        $petrinet->addArcs($this->arcs);
 
         return $petrinet;
     }

--- a/src/Petrinet/Place/Place.php
+++ b/src/Petrinet/Place/Place.php
@@ -45,14 +45,10 @@ class Place extends AbstractNode implements PlaceInterface
      * Sets the token bag.
      *
      * @param TokenBag $tokenBag The token bag
-     *
-     * @return Place This method is chainable
      */
     public function setTokenBag(TokenBag $tokenBag)
     {
         $this->tokenBag = $tokenBag;
-
-        return $this;
     }
 
     /**
@@ -69,14 +65,10 @@ class Place extends AbstractNode implements PlaceInterface
      * Adds a token.
      *
      * @param Token $token The token
-     *
-     * @return Place This method is chainable
      */
     public function addToken(Token $token)
     {
         $this->tokenBag->add($token);
-
-        return $this;
     }
 
     /**
@@ -89,14 +81,10 @@ class Place extends AbstractNode implements PlaceInterface
 
     /**
      * Removes all tokens.
-     *
-     * @return Place This method is chainable
      */
     public function clearTokens()
     {
         $this->tokenBag->clear();
-
-        return $this;
     }
 
     /**

--- a/src/Petrinet/Place/PlaceInterface.php
+++ b/src/Petrinet/Place/PlaceInterface.php
@@ -25,8 +25,6 @@ interface PlaceInterface extends \Countable, NodeInterface
      * Adds a token.
      *
      * @param Token $token The token
-     *
-     * @return PlaceInterface This method is chainable
      */
     public function addToken(Token $token);
 


### PR DESCRIPTION
Most interfaces didn't specify that $this is returned. It is also to stay compliant with Symfony standards.
Fluent interface is provided by the PetrinetBuilder.
