### PR TITLE
Fix empty input arcs

### DIFF
--- a/spec/Petrinet/Service/TransitionServiceSpec.php
+++ b/spec/Petrinet/Service/TransitionServiceSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Petrinet\Service;
 
+use Doctrine\Common\Collections\Collection;
 use Petrinet\Model\FactoryInterface;
 use Petrinet\Model\InputArcInterface;
 use Petrinet\Model\MarkingInterface;
@@ -51,6 +52,45 @@ class TransitionServiceSpec extends ObjectBehavior
 
         $this->beConstructedWith($factory);
         $this->isEnabled($transition, $marking)->shouldReturn(true);
+    }
+
+    function it_tells_a_transition_is_disabled_when_there_is_no_items_in_input_arcs_array(
+        FactoryInterface $factory,
+        InputArcInterface $arc,
+        PlaceInterface $place,
+        TransitionInterface $transition,
+        MarkingInterface $marking
+    )
+    {
+        $arc->getPlace()->willReturn($place);
+        $arc->getWeight()->willReturn(1);
+
+        $marking->getPlaceMarking($place->getWrappedObject())->willReturn(null);
+        $transition->getInputArcs()->willReturn(array());
+
+        $this->beConstructedWith($factory);
+        $this->isEnabled($transition, $marking)->shouldReturn(false);
+    }
+
+    function it_tells_a_transition_is_disabled_when_there_is_no_items_in_input_arcs_collection(
+        FactoryInterface $factory,
+        InputArcInterface $arc,
+        PlaceInterface $place,
+        TransitionInterface $transition,
+        MarkingInterface $marking,
+        Collection $inputArcs
+    )
+    {
+        $arc->getPlace()->willReturn($place);
+        $arc->getWeight()->willReturn(1);
+
+        $inputArcs->count()->willReturn(0);
+
+        $marking->getPlaceMarking($place->getWrappedObject())->willReturn(null);
+        $transition->getInputArcs()->willReturn($inputArcs);
+
+        $this->beConstructedWith($factory);
+        $this->isEnabled($transition, $marking)->shouldReturn(false);
     }
 
     function it_tells_a_transition_is_disabled_when_there_is_no_marking_for_the_input_places(

--- a/src/Petrinet/Service/TransitionService.php
+++ b/src/Petrinet/Service/TransitionService.php
@@ -47,7 +47,7 @@ class TransitionService implements TransitionServiceInterface
     {
         $inputArcs = $transition->getInputArcs();
 
-        if (empty($inputArcs)) {
+        if (count($inputArcs) === 0) {
             return false;
         }
 


### PR DESCRIPTION
Object of `ArrayCollection` is always not empty even though it does not contains any elements:

```
use Doctrine\Common\Collections\ArrayCollection;

$inputArcs = new ArrayCollection();

var_dump(empty($inputArcs));
```

This code print:
```
bool(false)
```

